### PR TITLE
Add private VC test

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,21 @@ For each node a **scrape config** needs to be added to `prometheus.yml`:
     metrics_path: '/metrics'
     scrape_interval: 5s
     static_configs:
-      - targets: [ 'nodes:1323']
+      - targets: [ 'nodeA:1323']
 ```
 
-Replace `node1` with the correct image name from the docker compose file.
+Replace `nodeA` with the correct image name from the docker compose file.
 
 The prometheus user interface is exposed on `localhost:9090`.
+
+#### Pushgateway
+
+Metrics that cannot be scraped (e.g. artillery) can be pushed to Prometheus using the [pushgateway](https://prometheus.io/docs/instrumenting/pushing/).
+The pushgateway acts as a scrapable source for the metrics pushed to it and is already in the Prometheus scrape config.
+Since the pushgateway acts as the source for the metrics, timestamps in Prometheus will correspond to when the metrics were scraped and not to when they were received by the gateway.
+Scraping will always return the most recently pushed results, even if no metrics have been received for a long time.
+
+[Artillery](https://www.artillery.io/docs/guides/plugins/plugin-publish-metrics#prometheus-pushgateway) metrics are exposed with `artillery_` prefix.
 
 ### Grafana
 

--- a/artillery/dids.yaml
+++ b/artillery/dids.yaml
@@ -1,4 +1,13 @@
 config:
+  plugins:
+    publish-metrics:
+      - type: prometheus
+        pushgateway: "http://pushgateway:9091"
+        tags:
+          - "testId:dids"
+          - "type:loadtest"
+
+
   target: "http://nodeA:1323"
   phases:
     - duration: 30

--- a/artillery/my-functions.js
+++ b/artillery/my-functions.js
@@ -1,0 +1,16 @@
+//
+// my-functions.js
+//
+module.exports = {
+    setJSONBody: setJSONBody,
+    logHeaders: logHeaders
+}
+
+function setJSONBody(requestParams, context, ee, next) {
+    return next(); // MUST be called for the scenario to continue
+}
+
+function logHeaders(requestParams, response, context, ee, next) {
+    console.log(response.headers);
+    return next(); // MUST be called for the scenario to continue
+}

--- a/artillery/my-functions.js
+++ b/artillery/my-functions.js
@@ -1,5 +1,6 @@
 //
 // my-functions.js
+// TODO: Change VC creation with a function.
 //
 module.exports = {
     setJSONBody: setJSONBody,

--- a/artillery/private-vcs.yaml
+++ b/artillery/private-vcs.yaml
@@ -1,0 +1,108 @@
+config:
+  plugins:
+    publish-metrics:
+      - type: prometheus
+        pushgateway: "http://pushgateway:9091"
+        tags: # add any tag you like as: "name:value"
+          - "testId:private-vcs"
+          - "type:loadtest"
+  target: "who.cares" # required, but urls are specified in the flows
+  processor: "/scripts/my-functions.js" # functions defined in here can be used by artillery
+  phases:
+    - duration: 120
+      arrivalRate: 100
+      maxVusers: 50
+      name: test
+
+# Setup test. Create 2 nodes with DIDs and NutsComm endpoints and restart them.
+before:
+  flow:
+    - log: "Creating DIDs"
+    - post:
+        url: "http://nodeA:1323/internal/vdr/v1/did"
+        capture:
+          - json: "$.id"
+            as: "didA"
+    - think: 4 # sync root
+    # needed for auto nodeDID resolver to kick in. requires strictmode==false
+    - post:
+        url: "http://nodeA:1323/internal/didman/v1/did/{{ didA }}/endpoint"
+        json:
+          type: "NutsComm"
+          endpoint: "grpc://nodeA:5555"
+    - post:
+        url: "http://nodeB:1323/internal/vdr/v1/did"
+        capture:
+          - json: "$.id"
+            as: "didB"
+    - post:
+        url: "http://nodeB:1323/internal/didman/v1/did/{{ didB }}/endpoint"
+        json:
+          type: "NutsComm"
+          endpoint: "grpc://nodeB:5555"
+    - think: 1
+
+    - log: "Restarting nodes"
+    - post:
+        url: "http://docker.api/containers/nodeA/restart"
+    - post:
+        url: "http://docker.api/containers/nodeB/restart"
+    - think: 5
+
+# artillery will select 1 of the flows during each run. The likelihood of a flow being selected is determined by its weight.
+scenarios:
+  - name: "Send private VC from nodeA"
+    weight: 4
+    flow:
+      - post:
+          url: "http://nodeA:1323/internal/vcr/v2/issuer/vc"
+          beforeRequest: "setJSONBody"
+          json:
+            "issuer": "{{ didA }}"
+            "type": "NutsAuthorizationCredential"
+            "credentialSubject":
+              "id": "{{ didB }}"
+              "legalBase":
+                "consentType": "implied"
+              "resources": [
+                {
+                  "path": "/patient/2250f7ab-6517-4923-ac00-88ed26f85843",
+                  "operations": [ "read" ],
+                  "userContext": true,
+                }
+              ]
+              "purposeOfUse": "performance-test"
+              "subject": "urn:oid:2.16.840.1.113883.2.4.6.3:123456780"
+            "visibility": "private"
+  - name: "Send private VC from nodeB"
+    weight: 1
+    flow:
+      - post:
+          url: "http://nodeB:1323/internal/vcr/v2/issuer/vc"
+          beforeRequest: "setJSONBody"
+          json:
+            "issuer": "{{ didB }}"
+            "type": "NutsAuthorizationCredential"
+            "credentialSubject":
+              "id": "{{ didA }}"
+              "legalBase":
+                "consentType": "implied"
+              "resources": [
+                {
+                  "path": "/patient/2250f7ab-6517-4923-ac00-88ed26f85843",
+                  "operations": [ "read" ],
+                  "userContext": true,
+                }
+              ]
+              "purposeOfUse": "performance-test"
+              "subject": "urn:oid:2.16.840.1.113883.2.4.6.3:123456780"
+            "visibility": "private"
+#  - name: "Rotate keys"
+#    weight: 1
+#    flow: TODO
+
+#after:
+#  flow:
+#    - log: "checking assertions"
+# add custom metric to check that all VC payloads have been retrieved
+# https://www.artillery.io/docs/guides/guides/extension-apis#custom-metrics-api

--- a/artillery/private-vcs.yaml
+++ b/artillery/private-vcs.yaml
@@ -9,10 +9,16 @@ config:
   target: "who.cares" # required, but urls are specified in the flows
   processor: "/scripts/my-functions.js" # functions defined in here can be used by artillery
   phases:
-    - duration: 120
-      arrivalRate: 100
-      maxVusers: 50
-      name: test
+    - duration: 30
+      arrivalRate: 10
+      name: Warm up
+    - duration: 600
+      arrivalRate: 10
+      rampTo: 150
+      name: Ramp up load
+    - duration: 300
+      arrivalRate: 150
+      name: Sustained load
 
 # Setup test. Create 2 nodes with DIDs and NutsComm endpoints and restart them.
 before:
@@ -56,7 +62,6 @@ scenarios:
     flow:
       - post:
           url: "http://nodeA:1323/internal/vcr/v2/issuer/vc"
-          beforeRequest: "setJSONBody"
           json:
             "issuer": "{{ didA }}"
             "type": "NutsAuthorizationCredential"
@@ -79,7 +84,6 @@ scenarios:
     flow:
       - post:
           url: "http://nodeB:1323/internal/vcr/v2/issuer/vc"
-          beforeRequest: "setJSONBody"
           json:
             "issuer": "{{ didB }}"
             "type": "NutsAuthorizationCredential"

--- a/monitor/docker-compose.yml
+++ b/monitor/docker-compose.yml
@@ -1,10 +1,9 @@
-version: "3.7"
-
 networks:
   default:
     name: performance-monitor
     external: true
 
+name: performance-test-monitor
 services:
   prometheus:
     image: 	prom/prometheus:latest
@@ -12,12 +11,16 @@ services:
       - "./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml"
     ports:
       - "9090:9090"
+  pushgateway:
+    image: prom/pushgateway:latest
+    ports:
+      - "9091:9091"
   grafana:
     image: grafana/grafana-oss:latest
-    environment:
-      GF_AUTH_ANONYMOUS_ENABLED: true
-      GF_AUTH_ORG_ROLE: viewer
-      GF_AUTH_DISABLE_LOGIN_FORM: true
+#    environment:
+#      GF_AUTH_ANONYMOUS_ENABLED: true
+#      GF_AUTH_ORG_ROLE: viewer
+#      GF_AUTH_DISABLE_LOGIN_FORM: true
     volumes:
       - "./grafana:/etc/grafana/provisioning:ro"
     ports:

--- a/monitor/docker-compose.yml
+++ b/monitor/docker-compose.yml
@@ -17,10 +17,10 @@ services:
       - "9091:9091"
   grafana:
     image: grafana/grafana-oss:latest
-#    environment:
-#      GF_AUTH_ANONYMOUS_ENABLED: true
-#      GF_AUTH_ORG_ROLE: viewer
-#      GF_AUTH_DISABLE_LOGIN_FORM: true
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: true
+      GF_AUTH_ORG_ROLE: viewer
+      GF_AUTH_DISABLE_LOGIN_FORM: true
     volumes:
       - "./grafana:/etc/grafana/provisioning:ro"
     ports:

--- a/monitor/prometheus/prometheus.yml
+++ b/monitor/prometheus/prometheus.yml
@@ -7,10 +7,13 @@ rule_files:
 # - "second.rules"
 
 scrape_configs:
+#  Docker: expose metrics first as per: https://docs.docker.com/config/daemon/prometheus/
   - job_name: docker
     scrape_interval: 5s
     static_configs:
-      - targets: ['host.docker.internal:9090']
+      - targets: ['host.docker.internal:9323']
+
+#  Nuts Nodes
   - job_name: nodeA
     scrape_interval: 5s
     static_configs:
@@ -23,6 +26,14 @@ scrape_configs:
       - targets:
         - 'nodeB:1323'
         - 'nodeB:9100'
+
+#  prometheus pushgateway allows scraping metrics that work on a push bases, like artillery
+  - job_name: pushgateway
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['pushgateway:9091']
+#    metrics_path: /api/v1/metrics
+    honor_labels: true  # preserves labels pushed to gateway
 
 # Redis
   ## config for the multiple Redis targets that the exporter will scrape

--- a/networks/README.md
+++ b/networks/README.md
@@ -56,4 +56,4 @@ Overrides for the nuts.yaml config, or additions to the configuration should be 
 
 The `<service>.container_name` field allows setting a fixed container name which is required to manage a container using the `docker.api` service.
 I.e., when the `container_name` is not set, the container for a service named `nodeA` will be renamed by compose to something like `performance-test-network-nodeA-1`.
-However, when the config contains `nodeA.container_name: nodeB`, the container will be named `nodeB` and can be manged through the API using this name (e.g., http://docker.api/containers/nodeB/json). 
+However, when the config contains `nodeA.container_name: nodeB`, the container for service `nodeA` will be named `nodeB` and can be manged through the API using this name (e.g., http://docker.api/containers/nodeB/json). 

--- a/networks/README.md
+++ b/networks/README.md
@@ -1,0 +1,59 @@
+
+# Creating a test setup
+To create a new test, copy the following config in to a new compose file at `./<test-name>/docker-compose.yml`.
+
+```yaml
+##### DOCKER NETWORK ASSIGNMENT #####
+# make sure prometheus is on the same network to scrape the metrics (run /monitor/docker-compose.yml)
+networks:
+  default:
+    name: performance-monitor
+    external: true
+    
+# Docker compose up/down acts on compose groups. 
+# Setting the same group name in all configs makes starting a new test a bit easier when there is another test active.
+name: performance-test-network 
+services:
+  ##### TEST CONFIGURATION #####
+  # Set test script to run in command
+  artillery:
+    image: artilleryio/artillery:latest
+    depends_on:
+      nodeA:
+        condition: service_healthy  # nodeA's healthcheck.interval determines how long this takes.
+    volumes: ["../../artillery:/scripts:ro"]
+    command: run /scripts/private-vcs.yaml  # <-- set test here
+  # This container exposes the docker rest api (https://docs.docker.com/engine/api/) on http://docker.api to other containers.
+  socat:
+    image: bobrik/socat
+    hostname: docker.api # give it an interpretable hostname
+    volumes: ["/var/run/docker.sock:/var/run/docker.sock:ro"]
+    command: TCP-LISTEN:80,fork UNIX-CONNECT:/var/run/docker.sock
+
+  ##### TEST NETWORK SETUP #####
+  # must contain at least a nodeA and nodeB
+  nodeA:
+    container_name: nodeA  # needed to manage container through docker APIs
+    image: &image nutsfoundation/nuts-node:dev
+    volumes: ["../nuts.yaml:/nuts.yaml:ro"]
+#    environment:
+#      ... add nuts.yaml overrides here
+    healthcheck:
+      interval: 5s
+  nodeB:
+    container_name: nodeB
+    image: *image
+    volumes: ["../nuts.yaml:/nuts.yaml:ro"]
+#    environment:
+#      ... add nuts.yaml overrides here
+```
+
+The compose file consists of 3 parts:
+- **DOCKER NETWORK ASSIGNMENT:**  this adds the services to the `performance-monitor` network so the containers can be scraped by prometheus.
+- **TEST CONFIGURATION:** this section runs the artillery test and exposes the docker APIs (on http://docker.api) to the network. This section should probably not be changed. (Besides the test to run.)
+- **TEST NETWORK SETUP:** this section in contains the network setup to test. It includes all nodes and additional containers needed for the test.
+Overrides for the nuts.yaml config, or additions to the configuration should be added as env variables. (Or mount a different nuts.yaml)  
+
+The `<service>.container_name` field allows setting a fixed container name which is required to manage a container using the `docker.api` service.
+I.e., when the `container_name` is not set, the container for a service named `nodeA` will be renamed by compose to something like `performance-test-network-nodeA-1`.
+However, when the config contains `nodeA.container_name: nodeB`, the container will be named `nodeB` and can be manged through the API using this name (e.g., http://docker.api/containers/nodeB/json). 

--- a/networks/baseline/docker-compose.yml
+++ b/networks/baseline/docker-compose.yml
@@ -1,45 +1,36 @@
-version: "3.7"
-
 networks:
   default:
     name: performance-monitor
     external: true
 
+name: performance-test-network
 services:
-  nodeA:
-    image: &image nutsfoundation/nuts-node:dev
-    environment:
-      NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
-    volumes:
-      - "../nuts.yaml:/opt/nuts/nuts.yaml:ro"
-      - "../tls-certs/nodeA-certificate.pem:/opt/nuts/certificate-and-key.pem:ro"
-      - "../tls-certs/truststore.pem:/opt/nuts/truststore.pem:ro"
-    ports:
-      - "11323:1323"
-      - "15555:5555"
-      - "19100:9100"
-    healthcheck:
-      interval: 5s
-  nodeB:
-    image: *image
-    environment:
-      NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
-      NUTS_NETWORK_BOOTSTRAPNODES: nodeA:5555
-    volumes:
-      - "../nuts.yaml:/opt/nuts/nuts.yaml:ro"
-      - "../tls-certs/nodeB-certificate.pem:/opt/nuts/certificate-and-key.pem:ro"
-      - "../tls-certs/truststore.pem:/opt/nuts/truststore.pem:ro"
-    ports:
-      - "21323:1323"
-      - "25555:5555"
-      - "29100:9100"
-    healthcheck:
-      interval: 5s
-
+  ##### TEST CONFIGURATION #####
   artillery:
     image: artilleryio/artillery:latest
     depends_on:
-      - nodeA
-    volumes:
-      - "../../artillery:/scripts:ro"
-    command: run /scripts/dids.yaml
+      nodeA:
+        condition: service_healthy
+    volumes: ["../../artillery:/scripts:ro"]
+    command: run /scripts/private-vcs.yaml
+  # This container exposes the docker rest api (https://docs.docker.com/engine/api/) on http://docker.api to other containers.
+  socat:
+    image: bobrik/socat
+    hostname: docker.api # give it an interpretable hostname
+    volumes: ["/var/run/docker.sock:/var/run/docker.sock:ro"]
+    command: TCP-LISTEN:80,fork UNIX-CONNECT:/var/run/docker.sock
+
+  ##### TEST NETWORK SETUP #####
+  # must contain at least a nodeA and nodeB
+  nodeA:
+    container_name: nodeA  # needed to manage container through docker APIs
+    image: &image nutsfoundation/nuts-node:dev
+    volumes: ["../nuts.yaml:/nuts.yaml:ro"]
+    ports:
+      - "11323:1323"
+    healthcheck:
+      interval: 5s
+  nodeB:
+    container_name: nodeB
+    image: *image
+    volumes: ["../nuts.yaml:/nuts.yaml:ro"]

--- a/networks/nuts.yaml
+++ b/networks/nuts.yaml
@@ -4,6 +4,11 @@ auth:
     - dummy
   irma:
     autoupdateschemas: false
+internalratelimiter: false
 network:
-  disablenodeauthentication: true
+  grpcaddr: :5555
+  v2:
+    gossipinterval: 5000
   enabletls: false
+  bootstrapnodes:
+    - nodeA:5555 # nodeA will also try to connect to itself and throw some errors

--- a/networks/redis/docker-compose.yml
+++ b/networks/redis/docker-compose.yml
@@ -1,47 +1,45 @@
-version: "3.7"
-
 networks:
   default:
     name: performance-monitor
     external: true
 
+name: performance-test-network
 services:
-  nodeA:
-    image: &image nutsfoundation/nuts-node:dev
+  ##### TEST CONFIGURATION #####
+  artillery:
+    image: artilleryio/artillery:latest
     depends_on:
-      - redisA
+      nodeA:
+        condition: service_healthy
+    volumes: ["../../artillery:/scripts:ro"]
+    command: run /scripts/private-vcs.yaml
+  # This container exposes the docker rest api (https://docs.docker.com/engine/api/) on http://docker.api to other containers.
+  socat:
+    image: bobrik/socat
+    hostname: docker.api # give it an interpretable hostname
+    volumes: ["/var/run/docker.sock:/var/run/docker.sock:ro"]
+    command: TCP-LISTEN:80,fork UNIX-CONNECT:/var/run/docker.sock
+
+  ##### TEST NETWORK SETUP #####
+  # must contain at least a nodeA and nodeB
+  nodeA:
+    container_name: nodeA  # used as docker container ID in artillery
+    image: &image nutsfoundation/nuts-node:dev
+    depends_on: [redisA]
     environment:
-      NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
       NUTS_STORAGE_REDIS_ADDRESS: "redisA:6379"
-    volumes:
-      - "../nuts.yaml:/opt/nuts/nuts.yaml:ro"
-      - "../tls-certs/nodeA-certificate.pem:/opt/nuts/certificate-and-key.pem:ro"
-      - "../tls-certs/truststore.pem:/opt/nuts/truststore.pem:ro"
+    volumes: ["../nuts.yaml:/nuts.yaml:ro"]
     ports:
       - "11323:1323"
-      - "15555:5555"
-      - "19100:9100"
     healthcheck:
       interval: 5s
-
   nodeB:
+    container_name: nodeB
     image: *image
-    depends_on:
-      - redisB
+    depends_on: [redisB]
     environment:
-      NUTS_CONFIGFILE: /opt/nuts/nuts.yaml
       NUTS_STORAGE_REDIS_ADDRESS: "redisB:6379"
-      NUTS_NETWORK_BOOTSTRAPNODES: "nodeA:5555"
-    volumes:
-      - "../nuts.yaml:/opt/nuts/nuts.yaml:ro"
-      - "../tls-certs/nodeB-certificate.pem:/opt/nuts/certificate-and-key.pem:ro"
-      - "../tls-certs/truststore.pem:/opt/nuts/truststore.pem:ro"
-    ports:
-      - "21323:1323"
-      - "25555:5555"
-      - "29100:9100"
-    healthcheck:
-      interval: 5s
+    volumes: ["../nuts.yaml:/nuts.yaml:ro"]
 
   redisA:
     image: redis:7
@@ -59,13 +57,3 @@ services:
     image: oliver006/redis_exporter:latest
     environment:
       REDIS_ADDR: "" # prevents scraping attempt on localhost, actual scape configs can be found in prometheus.yml
-    ports:
-      - "9121:9121"
-
-  artillery:
-    image: artilleryio/artillery:latest
-    depends_on:
-      - nodeA
-    volumes:
-      - "../../artillery:/scripts:ro"
-    command: run /scripts/dids.yaml


### PR DESCRIPTION
The test 
- creates 2 nodes with DIDs
- adds a NutsComm endpoint so the nodeDID can be auto-discovered after a restart
- restarts both nodes
- starts sending a lot of private VC's from both nodes with ratio 4:1 for nodeA:nodeB